### PR TITLE
Install required .NET SDK during CI build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,16 @@ branches:
   only:
     - master
 skip_tags: true
+environment:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+install:
+  - cmd: curl -OsSL https://dot.net/v1/dotnet-install.ps1
+  - ps: if ($isWindows) { ./dotnet-install.ps1 -JsonFile global.json }
+  - sh: curl -OsSL https://dot.net/v1/dotnet-install.sh
+  - sh: chmod +x dotnet-install.sh
+  - sh: ./dotnet-install.sh --jsonfile global.json
+  - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info
 build_script:


### PR DESCRIPTION
This PR will [install](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script) the required .NET SDK specified in `global.json` during a CI build, using .